### PR TITLE
Use vulkan-sdk-* tags and bump version to 1.4.328.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/KhronosGroup/Vulkan-Tools/archive/refs/tags/vulkan-sdk-{{ version }}.tar.gz
-  sha256: 0022b8b393ce1fce2c7c18890f6ab7abf9521c3b5a00143c4a11233d51e7b945
+  sha256: 617e91b396ac771869d62cd131f05dcc0b82d038744dab7f575bcf213852f8bf
 
 build:
   # osx requires MotlenVK which we do not package at conda-forge (yet?)


### PR DESCRIPTION
As done in vulkan-headers and vulkan-loader feedstocks, see:
* https://github.com/conda-forge/vulkan-loader-feedstock/blob/8ce533795cbe39933fb87d76ec10025095bea127/recipe/recipe.yaml#L11
* https://github.com/conda-forge/vulkan-headers-feedstock/blob/600959b07f6faa1d8903981ec1cffd7be315f0ee/recipe/recipe.yaml#L1

This avoid spurious PRs on tags not belonging to a vulkan-sdk release, such as https://github.com/conda-forge/vulkan-tools-feedstock/pull/27 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
